### PR TITLE
ci: change lint link trigger

### DIFF
--- a/.github/workflows/lint-links.yml
+++ b/.github/workflows/lint-links.yml
@@ -1,6 +1,9 @@
 name: Lint Links
 
 on:
+  pull_request:
+    paths:
+      - "specs/**"
   schedule:
     - cron: "0 0 * * *"
 jobs:
@@ -20,4 +23,4 @@ jobs:
           fields: repo,commit,author,action
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: failure()
+        if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
Change lint link so that it can also be triggered on pull requests

The pull request will be verified by the developer directly, so no additional alarms are required